### PR TITLE
Http11 predecessors polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Priorities
 Supported HTTP versions
 ======
 
-The main focus of this library is `HTTP/1.1`. See [tests](./tests)) for all covered cases. Precessors of `HTTP/1.1` don't support connection re-use which limits opportunities for HTTP Desync, however some proxies may upgrade such requests to `HTTP/1.1` and re-use backend connections, which may allow to craft malicious `HTTP/1.0` requests. That's why they are analyzed using the same criteria as `HTTP/1.1` with the following exception:
+The main focus of this library is `HTTP/1.1`. See [tests](./tests)) for all covered cases. Predecessors of `HTTP/1.1` don't support connection re-use which limits opportunities for HTTP Desync,
+however some proxies may upgrade such requests to `HTTP/1.1` and re-use backend connections, which may allow to craft malicious `HTTP/1.0` requests. 
+That's why they are analyzed using the same criteria as `HTTP/1.1`. For other protocol versions have the following exceptions:
 
+* `HTTP/0.9` requests are never considered `Compliant`, but are classified as `Acceptable`. If any of `Content-Length`/`Transfer-Encoding` is present then it's `Ambiguous`.
 * `HTTP/1.0` - the presence of `Transfer-Encoding` makes a request `Ambiguous`.
-
-`HTTP/0.9` requests are never considered `Compliant`, but `GET` requests without headers are classified as `Acceptable`, otherwise `Ambiguous`.
-
-`HTTP/2+` is out of scope. But if your proxy downgrades `HTTP/2` to `HTTP/1.1`, make sure the outgoing request is analyzed. 
+* `HTTP/2+` is out of scope. But if your proxy downgrades `HTTP/2` to `HTTP/1.1`, make sure the outgoing request is analyzed. 
 
 See [documentation](./docs) to learn more.
 

--- a/tests/ambiguous.yaml
+++ b/tests/ambiguous.yaml
@@ -397,6 +397,20 @@
     required_message_items:
       - "HTTP/0.9"
 
+- name: 'Content-Length for HTTP/0.9'
+  uri: /foo/bar
+  method: POST
+  version: HTTP/0.9
+  headers:
+    - name: Content-Length
+      value: 100
+      tier: NonCompliant
+  expected:
+    tier: Ambiguous
+    reason: UndefinedContentLengthSemantics
+    required_message_items:
+      - "HTTP/0.9"
+
 - name: "Transfer-Encoding for empty protocol, which is HTTP/0.9"
   uri: /foo/bar
   method: POST
@@ -408,6 +422,20 @@
   expected:
     tier: Ambiguous
     reason: UndefinedTransferEncodingSemantics
+    required_message_items:
+      - "HTTP/0.9"
+
+- name: "Content-Length for empty protocol, which is HTTP/0.9"
+  uri: /foo/bar
+  method: POST
+  version: ""
+  headers:
+    - name: Content-Length
+      value: 100
+      tier: NonCompliant
+  expected:
+    tier: Ambiguous
+    reason: UndefinedContentLengthSemantics
     required_message_items:
       - "HTTP/0.9"
 


### PR DESCRIPTION
*Description of changes:* More precise pre `HTTP/1.1` documentation and handling


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
