### PR TITLE
Fix a typo in analyze_raw_request.c.

### DIFF
--- a/misc/demo-c/analyze_parsed_request.c
+++ b/misc/demo-c/analyze_parsed_request.c
@@ -20,7 +20,6 @@
 #include <time.h>
 #include "defs.h"
 #include "http_desync_guardian.h"
-#include "http_desync_guardian_macros.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpointer-sign"
@@ -140,17 +139,6 @@ void initialize_http_desync_guardian()
             .callback = log_tier_metrics
     };
     http_desync_guardian_register_tier_metrics_callback(&tier_metrics_settings);
-
-    // initialize metrics
-    // query logging metrics internally set their own granular metrics settings
-    // if the granular metrics (Tier metrics in this case) have already been set
-    // then this call will not change the callback
-    http_desync_guardian_metrics_settings_t metrics_settings = {
-            .program = HDG_STRING("ProxyServiceFoo"),
-            .marketplace = HDG_STRING("BAR"),
-            .callback = log_metrics
-    };
-    http_desync_guardian_initialize_metrics_settings(&metrics_settings);
 
     // initialize logger
     http_desync_guardian_logging_settings_t logging_settings = {

--- a/misc/demo-c/analyze_raw_request.c
+++ b/misc/demo-c/analyze_raw_request.c
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "http_desync_guardian.h"
-#include "http_desync_guardian_macros.h"
 #include "defs.h"
 
 #pragma clang diagnostic push

--- a/misc/demo-c/analyze_raw_request.c
+++ b/misc/demo-c/analyze_raw_request.c
@@ -18,7 +18,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "http_desync_guardian.h"
-#incldesync_ude "http_guardian_macros.h"
+#include "http_desync_guardian_macros.h"
 #include "defs.h"
 
 #pragma clang diagnostic push


### PR DESCRIPTION
#9 

This commit fixes a typo in `analyze_raw_request.c`, but the header file is not in the repository.

Signed-off-by: Kuniyuki Iwashima <kuniyu@amazon.co.jp>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
