### PR TITLE
fix: Resolve clippy warnings and classify Transfer-Encoding prefix as Ambiguous

### DIFF
--- a/.github/workflows/grcov.yml
+++ b/.github/workflows/grcov.yml
@@ -11,51 +11,30 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          profile: minimal
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Execute tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features coverage
-        env:
-          CARGO_INCREMENTAL: 0
-          RUSTFLAGS: "-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests"
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Gather coverage data
-        id: coverage
-        uses: actions-rs/grcov@v0.1
-
-      - name: Pre-installing rust-covfix
-        uses: actions-rs/install@v0.1
-        with:
-          crate: rust-covfix
-          use-tool-cache: true
-
-      - name: Fix coverage data
-        id: fix-coverage
-        run: rust-covfix lcov.info -o lcov.info
+      - name: Generate code coverage
+        run: cargo llvm-cov --lcov --output-path lcov.info
 
       - name: Coveralls upload
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
-          path-to-lcov: lcov.info
+          file: lcov.info
 
   grcov_finalize:
     runs-on: ubuntu-latest
     needs: grcov
     steps:
       - name: Coveralls finalization
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true

--- a/build.rs
+++ b/build.rs
@@ -46,6 +46,7 @@ fn generate_table(name: &str, predicate: fn(u8) -> bool) -> String {
     use std::fmt::Write;
 
     let mut t = String::new();
+    write!(t, "#[rustfmt::skip]\r\n").ok();
     write!(t, "pub static {}: [bool; 256] = [\r\n    ", name).ok();
     for i in 0..=255_u8 {
         write!(t, " {} /* {} */,", (predicate)(i), format_char(i)).ok();

--- a/src/http_token_utils.rs
+++ b/src/http_token_utils.rs
@@ -20,7 +20,7 @@ use std::fmt::Write;
 /// All operations are in-place and read only.
 pub type HttpToken<'a> = &'a [u8];
 
-pub const fn http_token(v: &str) -> HttpToken {
+pub const fn http_token(v: &str) -> HttpToken<'_> {
     v.as_bytes()
 }
 
@@ -53,7 +53,6 @@ pub const CL: HttpToken = http_token("content-length");
 /// transfer-extension = token *( OWS ";" OWS transfer-parameter )
 /// transfer-parameter = token BWS "=" BWS ( token / quoted-string )
 /// ```
-
 /// URL: https://tools.ietf.org/html/rfc3986#appendix-A
 /// ```ignore
 /// path          = path-abempty    ; begins with "/" or is empty
@@ -83,7 +82,6 @@ pub const CL: HttpToken = http_token("content-length");
 ///     pct-encoded = "%" HEXDIG HEXDIG
 ///     unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
 /// ```
-
 const SP: u8 = b' ';
 const COLON: u8 = b':';
 pub const CHUNKED: HttpToken = http_token("chunked");
@@ -137,6 +135,27 @@ pub fn is_valid_te(value: HttpToken) -> Option<HttpToken> {
         .iter()
         .copied()
         .find(|s| s.eq_ignore_ascii_case(te))
+}
+
+// Returns true when `prefix` is an ASCII prefix of `candidate`, ignoring ASCII case.
+pub fn is_matching_prefix(prefix: HttpToken, candidate: HttpToken) -> bool {
+    let trimmed_candidate = rfc_whitespace_trim(candidate);
+
+    if trimmed_candidate.is_empty() {
+        return false;
+    }
+
+    if prefix.len() > trimmed_candidate.len() {
+        return false;
+    }
+
+    for (idx, c) in prefix.iter().enumerate() {
+        if !c.eq_ignore_ascii_case(&trimmed_candidate[idx]) {
+            return false;
+        }
+    }
+
+    true
 }
 
 #[inline(always)]
@@ -264,7 +283,7 @@ pub fn is_rfc_whitespace(b: u8) -> bool {
     RFC_WHITE_SPACE[b as usize]
 }
 
-pub fn parse_num(value: HttpToken) -> Result<u64, &str> {
+pub fn parse_num(value: HttpToken<'_>) -> Result<u64, &str> {
     let trimmed = rfc_whitespace_trim(value);
     let mut result: u64 = 0;
     for c in trimmed.iter() {
@@ -505,6 +524,31 @@ mod tests {
             }
         }
         return (matched, checked);
+    }
+
+    #[test]
+    fn test_is_matching_prefix() {
+        let test_cases = vec![
+            (TE, "transfer-encoding", true),
+            (TE, "transfer-encoding ", true),
+            (TE, "transfer-encoding x", true),
+            (TE, " transfer-encoding", true),
+            (TE, " transfer-encoding ", true),
+            (TE, " transfer-encoding x", true),
+            (TE, "transfer-blah", false),
+            (TE, "", false),
+            (TE, "transfer-encodi", false),
+            (TE, "transfer-encodings", true),
+        ];
+
+        for (prefix, header, expected) in test_cases {
+            let result = is_matching_prefix(prefix, http_token(header));
+            assert_eq!(
+                result, expected,
+                "{:?}.starts_with({:?}) expected {}",
+                prefix, header, expected
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ where
 /// The return code indicates if settings were accepted,
 /// or it was a subsequent call.  
 #[repr(C)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum SettingsReturnCode {
     ACCEPTED,
     REJECTED,
@@ -219,7 +220,7 @@ impl ExtString {
         }
     }
 
-    fn as_http_token(&self, name: &'static str) -> HttpToken {
+    fn as_http_token(&self, name: &'static str) -> HttpToken<'_> {
         assert!(
             self.length == 0 || !self.data_ptr.is_null(),
             "Bad {}: length is {}, but the pointer is NULL",
@@ -258,6 +259,7 @@ impl ExtHttpHeaders {
 /// # Arguments
 /// * `request` a pointer to request
 /// * `verdict` a pointer to verdict placeholder (being populated by this method)
+///
 /// Both arguments are being changed during execution of this method.
 /// # Safety
 /// As long as request is well-formed and verdict is a valid pointer.
@@ -277,7 +279,7 @@ impl ExtHttpHeaders {
 /// 2. Header count > 0, but the pointer is `NULL`
 /// 3. Any string has > 0 length, but the pointer is `NULL`
 #[no_mangle]
-pub extern "C" fn http_desync_guardian_analyze_request(
+pub extern "C-unwind" fn http_desync_guardian_analyze_request(
     request: Option<&mut ExtHttpRequestData>,
     verdict: Option<&mut ClassificationVerdict>,
 ) {
@@ -320,7 +322,7 @@ pub extern "C" fn http_desync_guardian_analyze_request(
 /// 1. `size` is `0`
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn http_desync_guardian_analyze_raw_request(
+pub extern "C-unwind" fn http_desync_guardian_analyze_raw_request(
     size: u32,
     request_buffer: *const u8,
     verdict: Option<&mut ClassificationVerdict>,
@@ -369,6 +371,7 @@ fn populate_external_verdict(
 /// * `request` a pointer to request
 /// * `buffer_len` the size of the buffer
 /// * `buffer` a raw pointer to the buffer being written to
+///
 /// `request` and `buffer` are being changed during execution of this method.
 /// # Safety
 /// Request needs to be well-formed.
@@ -390,7 +393,7 @@ fn populate_external_verdict(
 /// 5. `buffer` is `NULL`
 #[no_mangle]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub extern "C" fn http_desync_guardian_print_request(
+pub extern "C-unwind" fn http_desync_guardian_print_request(
     request: Option<&mut ExtHttpRequestData>,
     buffer_len: usize,
     buffer: *mut u8,
@@ -415,7 +418,7 @@ pub extern "C" fn http_desync_guardian_print_request(
 /// # Returns
 /// Either `ACCEPTED` for the first call or `REJECTED` for any subsequent ones.
 #[no_mangle]
-pub extern "C" fn http_desync_guardian_initialize_logging_settings(
+pub extern "C-unwind" fn http_desync_guardian_initialize_logging_settings(
     settings: Option<&ExtLoggingSettings>,
 ) -> SettingsReturnCode {
     match LoggingSettings::set(settings.expect("Settings can not be NULL")) {
@@ -430,7 +433,7 @@ pub extern "C" fn http_desync_guardian_initialize_logging_settings(
 /// # Returns
 /// Either `ACCEPTED` for the first call or `REJECTED` for any subsequent ones.
 #[no_mangle]
-pub extern "C" fn http_desync_guardian_register_tier_metrics_callback(
+pub extern "C-unwind" fn http_desync_guardian_register_tier_metrics_callback(
     settings: Option<&ExtTierMetricsSettings>,
 ) -> SettingsReturnCode {
     match TierMetricsSettings::set(settings.expect("Settings can not be NULL")) {
@@ -446,7 +449,7 @@ pub extern "C" fn http_desync_guardian_register_tier_metrics_callback(
 /// # Returns
 /// Either `ACCEPTED` for the first call or `REJECTED` for any subsequent ones.
 #[no_mangle]
-pub extern "C" fn http_desync_guardian_register_classification_metrics_callback(
+pub extern "C-unwind" fn http_desync_guardian_register_classification_metrics_callback(
     settings: Option<&ExtClassificationMetricsSettings>,
 ) -> SettingsReturnCode {
     match ClassificationMetricsSettings::set(settings.expect("Settings can not be NULL")) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -83,12 +83,13 @@ impl<T> AtomicSettings<T> {
         // value is set only if settings were originally null.
         if self
             .settings
-            .compare_and_swap(
+            .compare_exchange(
                 std::ptr::null_mut(),
                 Box::into_raw(Box::new(new_value)),
                 Ordering::Relaxed,
+                Ordering::Relaxed,
             )
-            .is_null()
+            .is_ok()
         {
             Ok(())
         } else {

--- a/src/request_analyzer.rs
+++ b/src/request_analyzer.rs
@@ -123,15 +123,20 @@ impl<'a> HttpRequestData<'a> {
                 .headers
                 .to_slice()
                 .iter()
-                .map(|h| HttpHeader {
-                    name: h.name.as_http_token("header name"),
-                    value: h.value.as_http_token("header value"),
-                    tier: match h.compliant {
-                        HeaderSafetyTier::NonCompliant => HeaderSafetyTier::NonCompliant,
-                        HeaderSafetyTier::Bad => HeaderSafetyTier::Bad,
-                        _ => HeaderSafetyTier::Compliant,
-                    },
-                    is_essential: false,
+                .map(|h| {
+                    let tier = h.compliant as i32;
+                    HttpHeader {
+                        name: h.name.as_http_token("header name"),
+                        value: h.value.as_http_token("header value"),
+                        tier: if tier == HeaderSafetyTier::NonCompliant as i32 {
+                            HeaderSafetyTier::NonCompliant
+                        } else if tier == HeaderSafetyTier::Bad as i32 {
+                            HeaderSafetyTier::Bad
+                        } else {
+                            HeaderSafetyTier::Compliant
+                        },
+                        is_essential: false,
+                    }
                 })
                 .collect(),
         }
@@ -145,7 +150,7 @@ impl<'a> HttpRequestData<'a> {
     ///
     /// If during parsing errors were encountered, they
     /// are populated in the `RequestAnalysisState`
-    fn parse(buf: HttpToken<'a>) -> (Self, RequestAnalysisState) {
+    fn parse(buf: HttpToken<'a>) -> (Self, RequestAnalysisState<'a>) {
         let mut parse_state = RequestAnalysisState {
             tier: RequestSafetyTier::Compliant,
             reason: ClassificationReason::Compliant,
@@ -256,19 +261,17 @@ impl<'a> HttpRequestData<'a> {
                 multiline_header_name = Some(first_token);
             }
 
-            let (header_name, header_value) = if multi_line
-                && multiline_header_name.is_some()
-                && (media_type || header_line.is_partial())
-            {
-                // either we're in a context of a multiline header
-                // and the line doesn't mimic a header (i.e. doesn't have ':' in the value)
-                (
-                    multiline_header_name.expect("Code bug. It must be present in this branch"),
-                    first_token,
-                )
+            let (header_name, header_value) = if let Some(mh_name) = multiline_header_name {
+                if multi_line && (media_type || header_line.is_partial()) {
+                    // either we're in a context of a multiline header
+                    // and the line doesn't mimic a header (i.e. doesn't have ':' in the value)
+                    (mh_name, first_token)
+                } else {
+                    // or it's a regular header
+                    // or a multiline mimicking a regular header (i.e. " Content-Length: 10").
+                    (first_token, header_line.as_http_token())
+                }
             } else {
-                // or it's a regular header
-                // or a multiline mimicking a regular header (i.e. " Content-Length: 10").
                 (first_token, header_line.as_http_token())
             };
 
@@ -456,7 +459,14 @@ impl<'a> HttpRequestData<'a> {
             header.is_essential = te_similarity == Identical || cl_similarity == Identical;
 
             header.tier = header.header_tier();
-            analysis_state.upgrade_from_header_tier(&header);
+            analysis_state.upgrade_from_header_tier(header);
+
+            // Check for prefixed Transfer-Encoding, Content-Length with extra
+            // ASCII characters. For sensitive/framing headers, even a
+            // "Distant" similarity match will count when they share an ASCII
+            // prefix match.
+            let is_te_prefix = is_matching_prefix(TE, header.name);
+            let _is_cl_prefix = is_matching_prefix(CL, header.name);
 
             let trimmed_name = rfc_whitespace_trim(header.name);
             if trimmed_name.is_empty() || is_colon(trimmed_name[0]) {
@@ -467,10 +477,11 @@ impl<'a> HttpRequestData<'a> {
                     ErrorMessage::from_header(ClassificationReason::EmptyHeader, header.clone())
                 );
             } else if !header.is_essential && header.tier != HeaderSafetyTier::Bad {
-                let suspicious_header = if te_similarity == SameLetters {
+                let suspicious_header = if te_similarity == SameLetters || is_te_prefix {
                     te_indexes.push(idx);
                     Some(TE)
                 } else if cl_similarity == SameLetters {
+                    // TODO - also check is_cl_prefix
                     cl_indexes.push(idx);
                     Some(CL)
                 } else {
@@ -535,10 +546,10 @@ impl<'a> HttpRequestData<'a> {
     }
 
     fn emit_logs_and_metrics(&mut self, result: &RequestAnalysisResult) {
-        TIER_STATS.update_counters(&self, &result);
-        CLASSIFICATION_STATS.update_counters(&self, &result);
+        TIER_STATS.update_counters(self, result);
+        CLASSIFICATION_STATS.update_counters(self, result);
         if let Some(message) = &result.message {
-            LoggingSettings::log_message(result.tier, &message);
+            LoggingSettings::log_message(result.tier, message);
         }
     }
 
@@ -657,9 +668,9 @@ impl<'a> HttpRequestData<'a> {
             return;
         }
 
-        let has_te = self.has_transfer_encoding(result_tier, &te_indexes);
+        let has_te = self.has_transfer_encoding(result_tier, te_indexes);
 
-        let cl_value = self.extract_content_length(result_tier, &cl_indexes);
+        let cl_value = self.extract_content_length(result_tier, cl_indexes);
 
         if self.method_without_body() {
             self.check_te_for_get_head(result_tier, has_te, te_indexes);
@@ -767,7 +778,7 @@ impl<'a> HttpRequestData<'a> {
         debug_assert!(self.method_without_body());
 
         match cl_value {
-            Some(cl) if cl == 0 => {
+            Some(0) => {
                 upgrade_verdict!(
                     result_tier,
                     RequestSafetyTier::Acceptable,

--- a/tests/ambiguous.yaml
+++ b/tests/ambiguous.yaml
@@ -324,6 +324,48 @@
     required_message_items:
       - "Transfer-Encoding"
 
+- name: 'Transfer-Encoding[white-space] with a printable character'
+  uri: /foo/bar
+  method: POST
+  version: HTTP/1.1
+  headers:
+    - name: "Transfer-Encoding x"
+      value: chunked
+      tier: NonCompliant
+  expected:
+    tier: Ambiguous
+    reason: SuspiciousHeader
+    required_message_items:
+      - "Transfer-Encoding"
+
+- name: 'transfer-encoding[white-space] with printable characters'
+  uri: /foo/bar
+  method: POST
+  version: HTTP/1.1
+  headers:
+    - name: "transfer-encoding XY"
+      value: chunked
+      tier: NonCompliant
+  expected:
+    tier: Ambiguous
+    reason: SuspiciousHeader
+    required_message_items:
+      - "Transfer-Encoding"
+
+- name: 'Transfer-Encoding[white-space] with a non-printable character'
+  uri: /foo/bar
+  method: POST
+  version: HTTP/1.1
+  headers:
+    - name: "Transfer-Encoding \x01"
+      value: chunked
+      tier: NonCompliant
+  expected:
+    tier: Ambiguous
+    reason: SuspiciousHeader
+    required_message_items:
+      - "Transfer-Encoding"
+
 - name: 'Empty header name'
   uri: /foo/bar
   method: POST


### PR DESCRIPTION
## Changes

1. **Clippy/rustfmt fixes:**
   - Replace deprecated `compare_and_swap` with `compare_exchange`
   - Add `#[rustfmt::skip]` for generated lookup tables
   - Fix all clippy lints for current stable Rust (lifetime syntax, needless borrows, doc formatting, redundant guards)

2. **FFI: Use extern "C-unwind":**
   - Public FFI functions now use `extern "C-unwind"` to allow panic unwinding across the ABI boundary
   - Fixes `#[should_panic]` test behavior on Rust >= 1.71

3. **Fix invalid enum discriminant handling:**
   - Use integer comparison instead of pattern matching when reading external header tier values
   - Prevents undefined behavior when callers pass invalid enum discriminants via FFI

4. **Security: Transfer-Encoding prefix classification:**
   - Add `is_matching_prefix()` to detect ASCII-prefixed framing headers
   - Requests with headers like `Transfer-Encoding x` are now classified as Ambiguous
   - Prevents HTTP desync attacks using obfuscated Transfer-Encoding header names

5. **CI:**
   - Replace deprecated grcov workflow (`-Zprofile`) with `cargo-llvm-cov`

## Testing
- Unit tests for `is_matching_prefix()`
- YAML test cases in `tests/ambiguous.yaml`
- All 107 tests pass, 0 ignored