### PR TITLE
fix: Add CL prefix detection and fix flaky metrics test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,15 @@ mod tests {
             &classification_metrics_settings,
         ));
 
-        analyze_vanilla_request();
+        // Retry to handle rate limiter contention from parallel tests.
+        // Each analyze_vanilla_request() call advances the synthetic test clock
+        // by 10s, moving to a new rate limiter time slot.
+        for _ in 0..3 {
+            analyze_vanilla_request();
+            if CLASSIFICATION_COUNT.load(Ordering::SeqCst) != 0 {
+                break;
+            }
+        }
 
         assert_ne!(CLASSIFICATION_COUNT.load(Ordering::SeqCst), 0);
     }

--- a/src/request_analyzer.rs
+++ b/src/request_analyzer.rs
@@ -471,7 +471,7 @@ impl<'a> HttpRequestData<'a> {
             // "Distant" similarity match will count when they share an ASCII
             // prefix match.
             let is_te_prefix = is_matching_prefix(TE, header.name);
-            let _is_cl_prefix = is_matching_prefix(CL, header.name);
+            let is_cl_prefix = is_matching_prefix(CL, header.name);
 
             let trimmed_name = rfc_whitespace_trim(header.name);
             if trimmed_name.is_empty() || is_colon(trimmed_name[0]) {
@@ -485,8 +485,7 @@ impl<'a> HttpRequestData<'a> {
                         suspicious_te_index = Some(idx);
                     }
                 }
-                if cl_similarity == SameLetters {
-                    // TODO - also check is_cl_prefix
+                if cl_similarity == SameLetters || is_cl_prefix {
                     header.tier = NonCompliant;
                     cl_indexes.push(idx);
                     if suspicious_cl_index.is_none() {


### PR DESCRIPTION
## Changes

1. **Fix CL prefix detection:**
   - Enable `is_cl_prefix` check in suspicious Content-Length header detection
   - Headers like `Content-Length x` are now correctly detected as suspicious
   - Mirrors the existing Transfer-Encoding prefix logic

2. **Fix flaky test:**
   - Add retry logic to `test_classification_reason_metrics_callback`
   - Handles rate limiter contention from parallel test execution

## Testing
- All 107 tests pass