### PR TITLE
fix: Update demo C files to use current enum names

### DIFF
--- a/misc/demo-c/analyze_raw_request.c
+++ b/misc/demo-c/analyze_raw_request.c
@@ -37,19 +37,19 @@ void analyze_raw_request()
     http_desync_guardian_analyze_raw_request(sizeof(request), request, &verdict);
 
     switch (verdict.tier) {
-        case REQUEST_SAFETY_TIER_COMPLIANT:
+        case HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_COMPLIANT:
             // the request is good. green light
             printf("Request is OK\n");
             break;
-        case REQUEST_SAFETY_TIER_ACCEPTABLE:
+        case HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_ACCEPTABLE:
             // the request is acceptable, as Transfer-Encoding and Content-Length are good. green light
             printf("Request is OK-ish\n");
             break;
-        case REQUEST_SAFETY_TIER_AMBIGUOUS:
+        case HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_AMBIGUOUS:
             // the request is suspicious. you can send it, but close both FE/BE connections immediately
             printf("Request is Ambiguous: %.*s\n", verdict.message_length, verdict.message_data);
             break;
-        case REQUEST_SAFETY_TIER_SEVERE:
+        case HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_SEVERE:
             // send 400 and close the connection
             printf("Request is BAD: %.*s\n", verdict.message_length, verdict.message_data);
             break;

--- a/misc/demo-nginx/http_desync_guardian_detect_module.c
+++ b/misc/demo-nginx/http_desync_guardian_detect_module.c
@@ -59,19 +59,19 @@ static ngx_int_t http_desync_guardian_detect_construct_request(http_desync_guard
 
 http_desync_guardian_detect_enum_mapping_t http_desync_guardian_detect_tier_str[] = {
         {
-                .enum_value = REQUEST_SAFETY_TIER_COMPLIANT,
+                .enum_value = HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_COMPLIANT,
                 .str_value  = ngx_null_string,  //'-' for Compliant
         },
         {
-                .enum_value = REQUEST_SAFETY_TIER_ACCEPTABLE,
+                .enum_value = HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_ACCEPTABLE,
                 .str_value  = ngx_string("Acceptable"),
         },
         {
-                .enum_value = REQUEST_SAFETY_TIER_AMBIGUOUS,
+                .enum_value = HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_AMBIGUOUS,
                 .str_value  = ngx_string("Ambiguous"),
         },
         {
-                .enum_value = REQUEST_SAFETY_TIER_SEVERE,
+                .enum_value = HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_SEVERE,
                 .str_value  = ngx_string("Severe"),
         }
 };


### PR DESCRIPTION
## Changes

Update enum references in demo C files to match the current cbindgen-generated header names.

- `REQUEST_SAFETY_TIER_*` -> `HTTP_DESYNC_GUARDIAN_REQUEST_SAFETY_TIER_T_*`
- `HEADER_SAFETY_TIER_*` -> `HTTP_DESYNC_GUARDIAN_HEADER_SAFETY_TIER_T_*`
- Fix missing newline at end of file

Fixes #13